### PR TITLE
Fixing potential race condition: igb_down vs igb_watchdog_task

### DIFF
--- a/kmod/igb_main.c
+++ b/kmod/igb_main.c
@@ -1878,6 +1878,15 @@ void igb_down(struct igb_adapter *adapter)
 	struct e1000_hw *hw = &adapter->hw;
 	u32 tctl, rctl;
 	int i;
+   
+    /* deleting timer and work queue sync 
+       of igb_watchdog task at the begining
+       to avoid race condition between igb_down
+       and watchdog - performing required actions
+       before altering the adapter state and registers
+     */
+    del_timer_sync(&adapter->watchdog_timer);
+    cancel_work_sync(&adapter->watchdog_task);    
 
 	/* signal that we're down so the interrupt handler does not
 	 * reschedule our watchdog timer
@@ -1906,8 +1915,7 @@ void igb_down(struct igb_adapter *adapter)
 	igb_irq_disable(adapter);
 
 	adapter->flags &= ~IGB_FLAG_NEED_LINK_UPDATE;
-
-	del_timer_sync(&adapter->watchdog_timer);
+	
 	if (adapter->flags & IGB_FLAG_DETECT_BAD_DMA)
 		del_timer_sync(&adapter->dma_err_timer);
 	del_timer_sync(&adapter->phy_info_timer);

--- a/kmod/igb_main.c
+++ b/kmod/igb_main.c
@@ -1879,14 +1879,14 @@ void igb_down(struct igb_adapter *adapter)
 	u32 tctl, rctl;
 	int i;
    
-    /* deleting timer and work queue sync 
-       of igb_watchdog task at the begining
-       to avoid race condition between igb_down
-       and watchdog - performing required actions
-       before altering the adapter state and registers
-     */
-    del_timer_sync(&adapter->watchdog_timer);
-    cancel_work_sync(&adapter->watchdog_task);    
+    	/* deleting timer and work queue sync 
+       	of igb_watchdog task at the begining
+       	to avoid race condition between igb_down
+       	and watchdog - performing required actions
+       	before altering the adapter state and registers
+     	*/
+    	del_timer_sync(&adapter->watchdog_timer);
+    	cancel_work_sync(&adapter->watchdog_task);    
 
 	/* signal that we're down so the interrupt handler does not
 	 * reschedule our watchdog timer


### PR DESCRIPTION
This is a change oriented around resolving an issue with potential race condition between igb_down invocation and igb_watchdog_task. One of top Automotive customers reproduced an issue where the driver code, while going into down state, invoked igb_down() but at the same time an igb_watchdog_task has been scheduled by the kernel. The result was that igb_down() (which managed to already go to the place where it freed memory resources) has been interrupted by igb_watchdog_task call. As a consequence an attempt to service sending a packet on freed resources has been done, which resulted in kernel crash. This change addresses that issue by:

a) adding cancel_work_sync() kernel method that is supposed to delete the synchronization created while performing schedule_work()

b) moving the code at the very beginning of igb_down() so that no code from igb_down() implementation will be executed before cancelling the synchronization (no register alteration, no adapter state setting etc)

Thank to that change we are sure that we will no longer accept operating/servicing late igb_watchodog_task requests on previously freed resources.

Change has been verified and accepted by the customer itself.