### PR TITLE
Fix build on kernel 4.19

### DIFF
--- a/kmod/igb_main.c
+++ b/kmod/igb_main.c
@@ -134,7 +134,10 @@ static void igb_dma_err_timer(unsigned long data);
 static void igb_watchdog_task(struct work_struct *);
 static void igb_dma_err_task(struct work_struct *);
 /* AVB specific */
-#ifdef HAVE_NDO_SELECT_QUEUE_ACCEL_FALLBACK
+#if defined HAVE_NDO_SELECT_QUEUE_SB_DEV
+static u16 igb_select_queue(struct net_device *dev, struct sk_buff *skb,
+		struct net_device *sb_dev, select_queue_fallback_t fallback);
+#elif defined HAVE_NDO_SELECT_QUEUE_ACCEL_FALLBACK
 static u16 igb_select_queue(struct net_device *dev, struct sk_buff *skb,
 		void *accel_priv, select_queue_fallback_t fallback);
 #else
@@ -5787,9 +5790,12 @@ static inline struct igb_ring *igb_tx_queue_mapping(struct igb_adapter *adapter,
 #error Must have multi-queue tx support enabled (CONFIG_NETDEVICES_MULTIQUEUE)!
 #endif
 
-#ifdef HAVE_NDO_SELECT_QUEUE_ACCEL_FALLBACK
+#if defined HAVE_NDO_SELECT_QUEUE_SB_DEV
 static u16 igb_select_queue(struct net_device *dev, struct sk_buff *skb,
-			    void *accel_priv, select_queue_fallback_t fallback)
+		struct net_device *sb_dev, select_queue_fallback_t fallback)
+#elif defined HAVE_NDO_SELECT_QUEUE_ACCEL_FALLBACK
+static u16 igb_select_queue(struct net_device *dev, struct sk_buff *skb,
+		void *accel_priv, select_queue_fallback_t fallback)
 #else
 static u16 igb_select_queue(struct net_device *dev, struct sk_buff *skb)
 #endif

--- a/kmod/kcompat.h
+++ b/kmod/kcompat.h
@@ -4704,4 +4704,9 @@ static inline bool page_is_pfmemalloc(struct page __maybe_unused *page)
 #define HAVE_GENEVE_RX_OFFLOAD
 #endif /* 4.5.0 */
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,19,0))
+#else
+#define HAVE_NDO_SELECT_QUEUE_SB_DEV
+#endif /* 4.19.0 */
+
 #endif /* _KCOMPAT_H_ */


### PR DESCRIPTION
Kernel 4.19 has changed function `ndo_select_queue` signature, so it's
necessary to update its use here - or it won't build against 4.19 kernels.

As the parameter changed wasn't used, it's only a matter of updating
the corresponding signature here.