### PR TITLE
kmod/Makefile: Fix depmod KVER in install target

### DIFF
--- a/kmod/Makefile
+++ b/kmod/Makefile
@@ -347,7 +347,7 @@ else
   ifeq ($(DEPVER),1 )
 	/sbin/depmod -r $(INSTALL_MOD_PATH) -a || true
   else
-	/sbin/depmod -b $(INSTALL_MOD_PATH) -a -n $(KVER) > /dev/null || true
+	/sbin/depmod -b $(INSTALL_MOD_PATH) -a $(KVER) || true
   endif
 endif
 	install -D -m 644 $(MANFILE).gz $(INSTALL_MOD_PATH)$(MANDIR)/man$(MANSECTION)/$(MANFILE).gz

--- a/kmod/Makefile
+++ b/kmod/Makefile
@@ -347,7 +347,7 @@ else
   ifeq ($(DEPVER),1 )
 	/sbin/depmod -r $(INSTALL_MOD_PATH) -a || true
   else
-	/sbin/depmod -b $(INSTALL_MOD_PATH) -a -n $(KVERSION) > /dev/null || true
+	/sbin/depmod -b $(INSTALL_MOD_PATH) -a -n $(KVER) > /dev/null || true
   endif
 endif
 	install -D -m 644 $(MANFILE).gz $(INSTALL_MOD_PATH)$(MANDIR)/man$(MANSECTION)/$(MANFILE).gz


### PR DESCRIPTION
Fix a typo in the depmod command, which causes the install target to
fail when generating modules.dep.

Signed-off-by: Thomas Preston <thomas.preston@codethink.co.uk>