### PR TITLE
Support for kernel 4.20

### DIFF
--- a/kmod/igb_ethtool.c
+++ b/kmod/igb_ethtool.c
@@ -155,15 +155,28 @@ static const char igb_gstrings_test[][ETH_GSTRING_LEN] = {
 #define IGB_TEST_LEN (sizeof(igb_gstrings_test) / ETH_GSTRING_LEN)
 #endif /* ETHTOOL_TEST */
 
+#ifdef IGB_SETTINGS_NEWETHOPS
+static int igb_get_settings(struct net_device *netdev, struct ethtool_link_ksettings *ecmd)
+#else	
 static int igb_get_settings(struct net_device *netdev, struct ethtool_cmd *ecmd)
+#endif
 {
 	struct igb_adapter *adapter = netdev_priv(netdev);
 	struct e1000_hw *hw = &adapter->hw;
 	u32 status;
+	u32 advertising;
+	u32 supported;
+	u32 speed;
+	u8 port;
+	u8 duplex;
+	u8 transceiver;
+	u8 autoneg;
+	u8 eth_tp_mdix;
+	u8 eth_tp_mdix_ctrl;
 
 	if (hw->phy.media_type == e1000_media_type_copper) {
 
-		ecmd->supported = (SUPPORTED_10baseT_Half |
+		supported = (SUPPORTED_10baseT_Half |
 				   SUPPORTED_10baseT_Full |
 				   SUPPORTED_100baseT_Half |
 				   SUPPORTED_100baseT_Full |
@@ -171,63 +184,67 @@ static int igb_get_settings(struct net_device *netdev, struct ethtool_cmd *ecmd)
 				   SUPPORTED_Autoneg |
 				   SUPPORTED_TP |
 				   SUPPORTED_Pause);
-		ecmd->advertising = ADVERTISED_TP;
+		advertising = ADVERTISED_TP;
 
 		if (hw->mac.autoneg == 1) {
-			ecmd->advertising |= ADVERTISED_Autoneg;
+			advertising |= ADVERTISED_Autoneg;
 			/* the e1000 autoneg seems to match ethtool nicely */
-			ecmd->advertising |= hw->phy.autoneg_advertised;
+			advertising |= hw->phy.autoneg_advertised;
 		}
 
-		ecmd->port = PORT_TP;
+		port = PORT_TP;
+#ifdef IGB_SETTINGS_NEWETHOPS
+		ecmd->base.phy_address = hw->phy.addr;
+#else
 		ecmd->phy_address = hw->phy.addr;
-		ecmd->transceiver = XCVR_INTERNAL;
+#endif
+		transceiver = XCVR_INTERNAL;
 
 	} else {
-		ecmd->supported = (SUPPORTED_1000baseT_Full |
+		supported = (SUPPORTED_1000baseT_Full |
 				   SUPPORTED_100baseT_Full |
 				   SUPPORTED_FIBRE |
 				   SUPPORTED_Autoneg |
 				   SUPPORTED_Pause);
 		if (hw->mac.type == e1000_i354)
-			ecmd->supported |= (SUPPORTED_2500baseX_Full);
+			supported |= (SUPPORTED_2500baseX_Full);
 
-		ecmd->advertising = ADVERTISED_FIBRE;
+		advertising = ADVERTISED_FIBRE;
 
 		switch (adapter->link_speed) {
 		case SPEED_2500:
-			ecmd->advertising = ADVERTISED_2500baseX_Full;
+			advertising = ADVERTISED_2500baseX_Full;
 			break;
 		case SPEED_1000:
-			ecmd->advertising = ADVERTISED_1000baseT_Full;
+			advertising = ADVERTISED_1000baseT_Full;
 			break;
 		case SPEED_100:
-			ecmd->advertising = ADVERTISED_100baseT_Full;
+			advertising = ADVERTISED_100baseT_Full;
 			break;
 		default:
 			break;
 		}
 
 		if (hw->mac.autoneg == 1)
-			ecmd->advertising |= ADVERTISED_Autoneg;
+			advertising |= ADVERTISED_Autoneg;
 
-		ecmd->port = PORT_FIBRE;
-		ecmd->transceiver = XCVR_EXTERNAL;
+		port = PORT_FIBRE;
+		transceiver = XCVR_EXTERNAL;
 	}
 
 	if (hw->mac.autoneg != 1)
-		ecmd->advertising &= ~(ADVERTISED_Pause |
+		advertising &= ~(ADVERTISED_Pause |
 				       ADVERTISED_Asym_Pause);
 
 	if (hw->fc.requested_mode == e1000_fc_full)
-		ecmd->advertising |= ADVERTISED_Pause;
+		advertising |= ADVERTISED_Pause;
 	else if (hw->fc.requested_mode == e1000_fc_rx_pause)
-		ecmd->advertising |= (ADVERTISED_Pause |
+		advertising |= (ADVERTISED_Pause |
 				      ADVERTISED_Asym_Pause);
 	else if (hw->fc.requested_mode == e1000_fc_tx_pause)
-		ecmd->advertising |=  ADVERTISED_Asym_Pause;
+		advertising |=  ADVERTISED_Asym_Pause;
 	else
-		ecmd->advertising &= ~(ADVERTISED_Pause |
+		advertising &= ~(ADVERTISED_Pause |
 				       ADVERTISED_Asym_Pause);
 
 	status = E1000_READ_REG(hw, E1000_STATUS);
@@ -236,56 +253,94 @@ static int igb_get_settings(struct net_device *netdev, struct ethtool_cmd *ecmd)
 		if ((hw->mac.type == e1000_i354) &&
 		    (status & E1000_STATUS_2P5_SKU) &&
 		    !(status & E1000_STATUS_2P5_SKU_OVER))
-			ethtool_cmd_speed_set(ecmd, SPEED_2500);
+			 speed = SPEED_2500;
 		else if (status & E1000_STATUS_SPEED_1000)
-			ethtool_cmd_speed_set(ecmd, SPEED_1000);
+			speed = SPEED_1000;
 		else if (status & E1000_STATUS_SPEED_100)
-			ethtool_cmd_speed_set(ecmd, SPEED_100);
+			speed = SPEED_100;
 		else
-			ethtool_cmd_speed_set(ecmd, SPEED_10);
+			speed = SPEED_10;
 
 		if ((status & E1000_STATUS_FD) ||
 		    hw->phy.media_type != e1000_media_type_copper)
-			ecmd->duplex = DUPLEX_FULL;
+			duplex = DUPLEX_FULL;
 		else
-			ecmd->duplex = DUPLEX_HALF;
+			duplex = DUPLEX_HALF;
 
 	} else {
-		ethtool_cmd_speed_set(ecmd, SPEED_UNKNOWN);
-		ecmd->duplex = -1;
+		 speed = SPEED_UNKNOWN;
+		 duplex = -1;
 	}
 
 	if ((hw->phy.media_type == e1000_media_type_fiber) ||
 	    hw->mac.autoneg)
-		ecmd->autoneg = AUTONEG_ENABLE;
+		autoneg = AUTONEG_ENABLE;
 	else
-		ecmd->autoneg = AUTONEG_DISABLE;
+		autoneg = AUTONEG_DISABLE;
 #ifdef ETH_TP_MDI_X
 
 	/* MDI-X => 2; MDI =>1; Invalid =>0 */
 	if (hw->phy.media_type == e1000_media_type_copper)
-		ecmd->eth_tp_mdix = hw->phy.is_mdix ? ETH_TP_MDI_X :
-						      ETH_TP_MDI;
+		eth_tp_mdix = hw->phy.is_mdix ? ETH_TP_MDI_X :
+						      ETH_TP_MDI; 
 	else
-		ecmd->eth_tp_mdix = ETH_TP_MDI_INVALID;
+		eth_tp_mdix = ETH_TP_MDI_INVALID;
 
 #ifdef ETH_TP_MDI_AUTO
 	if (hw->phy.mdix == AUTO_ALL_MODES)
-		ecmd->eth_tp_mdix_ctrl = ETH_TP_MDI_AUTO;
+		eth_tp_mdix_ctrl = ETH_TP_MDI_AUTO;
 	else
-		ecmd->eth_tp_mdix_ctrl = hw->phy.mdix;
+		eth_tp_mdix_ctrl = hw->phy.mdix;
 
 #endif
-#endif /* ETH_TP_MDI_X */
+#endif
+#ifdef IGB_SETTINGS_NEWETHOPS
+	ethtool_convert_legacy_u32_to_link_mode(ecmd->link_modes.advertising, advertising);
+	ethtool_convert_legacy_u32_to_link_mode(ecmd->link_modes.supported, supported);
+	ecmd->base.transceiver = transceiver;
+	ecmd->base.port = port;
+	ecmd->base.duplex = duplex;
+	ecmd->base.speed = speed;
+	ecmd->base.autoneg = autoneg;
+	ecmd->base.eth_tp_mdix = eth_tp_mdix;
+	ecmd->base.eth_tp_mdix_ctrl = eth_tp_mdix_ctrl;
+#else
+	ethtool_cmd_speed_set(ecmd, speed);
+	ecmd->transceiver = transceiver;
+	ecmd->port = port;
+	ecmd->duplex = duplex;
+	ecmd->autoneg = autoneg;
+	ecmd->eth_tp_mdix = eth_tp_mdix;
+	ecmd->eth_tp_mdix_ctrl = eth_tp_mdix_ctrl;
+	ecmd->advertising = advertising;
+	ecmd->supported = supported;
+#endif
+
 	return 0;
 }
-
+ 
+#ifdef IGB_SETTINGS_NEWETHOPS
+static int igb_set_settings(struct net_device *netdev, const struct ethtool_link_ksettings *ecmd)
+#else
 static int igb_set_settings(struct net_device *netdev, struct ethtool_cmd *ecmd)
-{
+#endif
+{	
+#ifdef IGB_SETTINGS_NEWETHOPS
+	u32 advertising = (u32)*(ecmd->link_modes.advertising);
+	u8 duplex = ecmd->base.duplex;
+	u8 eth_tp_mdix_ctrl = ecmd->base.eth_tp_mdix_ctrl;
+	u8 autoneg = ecmd->base.autoneg;
+	u32 speed = ecmd->base.speed;
+#else
+	u32 advertising = ecmd->advertising;
+	u8 duplex = ecmd->duplex;
+	u8 eth_tp_mdix_ctrl = ecmd->eth_tp_mdix_ctrl;
+	u8 autoneg = ecmd->autoneg;
+	u16 speed = ecmd->speed;
+#endif
 	struct igb_adapter *adapter = netdev_priv(netdev);
 	struct e1000_hw *hw = &adapter->hw;
-
-	if (ecmd->duplex  == DUPLEX_HALF) {
+	if (duplex  == DUPLEX_HALF) {
 		if (!hw->dev_spec._82575.eee_disable)
 			dev_info(pci_dev_to_dev(adapter->pdev), "EEE disabled: not supported with half duplex\n");
 		hw->dev_spec._82575.eee_disable = true;
@@ -308,12 +363,12 @@ static int igb_set_settings(struct net_device *netdev, struct ethtool_cmd *ecmd)
 	 * some hardware doesn't allow MDI setting when speed or
 	 * duplex is forced.
 	 */
-	if (ecmd->eth_tp_mdix_ctrl) {
+	if (eth_tp_mdix_ctrl) {
 		if (hw->phy.media_type != e1000_media_type_copper)
 			return -EOPNOTSUPP;
 
-		if ((ecmd->eth_tp_mdix_ctrl != ETH_TP_MDI_AUTO) &&
-		    (ecmd->autoneg != AUTONEG_ENABLE)) {
+		if ((eth_tp_mdix_ctrl != ETH_TP_MDI_AUTO) &&
+		    (autoneg != AUTONEG_ENABLE)) {
 			dev_err(&adapter->pdev->dev, "forcing MDI/MDI-X state is not supported when link speed and/or duplex are forced\n");
 			return -EINVAL;
 		}
@@ -323,10 +378,10 @@ static int igb_set_settings(struct net_device *netdev, struct ethtool_cmd *ecmd)
 	while (test_and_set_bit(__IGB_RESETTING, &adapter->state))
 		usleep_range(1000, 2000);
 
-	if (ecmd->autoneg == AUTONEG_ENABLE) {
+	if (autoneg == AUTONEG_ENABLE) {
 		hw->mac.autoneg = 1;
 		if (hw->phy.media_type == e1000_media_type_fiber) {
-			hw->phy.autoneg_advertised = ecmd->advertising |
+			hw->phy.autoneg_advertised = advertising |
 						     ADVERTISED_FIBRE |
 						     ADVERTISED_Autoneg;
 			switch (adapter->link_speed) {
@@ -346,15 +401,15 @@ static int igb_set_settings(struct net_device *netdev, struct ethtool_cmd *ecmd)
 				break;
 			}
 		} else {
-			hw->phy.autoneg_advertised = ecmd->advertising |
+			hw->phy.autoneg_advertised = advertising |
 						     ADVERTISED_TP |
 						     ADVERTISED_Autoneg;
 		}
-		ecmd->advertising = hw->phy.autoneg_advertised;
+		advertising = hw->phy.autoneg_advertised;
 		if (adapter->fc_autoneg)
 			hw->fc.requested_mode = e1000_fc_default;
 	} else {
-		if (igb_set_spd_dplx(adapter, ecmd->speed + ecmd->duplex)) {
+		if (igb_set_spd_dplx(adapter, speed + duplex)) {
 			clear_bit(__IGB_RESETTING, &adapter->state);
 			return -EINVAL;
 		}
@@ -362,14 +417,14 @@ static int igb_set_settings(struct net_device *netdev, struct ethtool_cmd *ecmd)
 
 #ifdef ETH_TP_MDI_AUTO
 	/* MDI-X => 2; MDI => 1; Auto => 3 */
-	if (ecmd->eth_tp_mdix_ctrl) {
+	if (eth_tp_mdix_ctrl) {
 		/* fix up the value for auto (3 => 0) as zero is mapped
 		 * internally to auto
 		 */
-		if (ecmd->eth_tp_mdix_ctrl == ETH_TP_MDI_AUTO)
+		if (eth_tp_mdix_ctrl == ETH_TP_MDI_AUTO)
 			hw->phy.mdix = AUTO_ALL_MODES;
 		else
-			hw->phy.mdix = ecmd->eth_tp_mdix_ctrl;
+			hw->phy.mdix = eth_tp_mdix_ctrl;
 	}
 
 #endif /* ETH_TP_MDI_AUTO */
@@ -3084,8 +3139,6 @@ static int igb_set_channels(struct net_device *dev,
 
 #endif /* ETHTOOL_SCHANNELS */
 static const struct ethtool_ops igb_ethtool_ops = {
-	.get_settings           = igb_get_settings,
-	.set_settings           = igb_set_settings,
 	.get_drvinfo            = igb_get_drvinfo,
 	.get_regs_len           = igb_get_regs_len,
 	.get_regs               = igb_get_regs,
@@ -3104,6 +3157,14 @@ static const struct ethtool_ops igb_ethtool_ops = {
 	.set_pauseparam         = igb_set_pauseparam,
 	.self_test              = igb_diag_test,
 	.get_strings            = igb_get_strings,
+
+#ifdef IGB_SETTINGS_NEWETHOPS
+	.get_link_ksettings	 = igb_get_settings,
+	.set_link_ksettings	 = igb_set_settings,
+#else
+	.get_settings	 = igb_get_settings,
+	.set_settings	 = igb_set_settings,
+#endif
 #ifndef HAVE_RHEL6_ETHTOOL_OPS_EXT_STRUCT
 #ifdef HAVE_ETHTOOL_SET_PHYS_ID
 	.set_phys_id            = igb_set_phys_id,

--- a/kmod/kcompat.h
+++ b/kmod/kcompat.h
@@ -4704,6 +4704,10 @@ static inline bool page_is_pfmemalloc(struct page __maybe_unused *page)
 #define HAVE_GENEVE_RX_OFFLOAD
 #endif /* 4.5.0 */
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,20,0))
+#define IGB_SETTINGS_NEWETHOPS
+#endif
+
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4,19,0))
 #else
 #define HAVE_NDO_SELECT_QUEUE_SB_DEV


### PR DESCRIPTION
It is adjustement of the driver connected with issue #16. This patch with support for older kernel versions. We need to keep compatibility with older version. So, in version 4.20 and newer, we use new function pointers {get | set}_link_ksettings and past function pointers ({get | set}_settings) for older versions.
