### PR TITLE
Fixing potential error when hw->hw_addr == NULL

### DIFF
--- a/kmod/igb.h
+++ b/kmod/igb.h
@@ -561,7 +561,6 @@ struct igb_adapter {
 	u16 link_speed;
 	u16 link_duplex;
 	u8 port_num;
-
 	/* Interrupt Throttle Rate */
 	u32 rx_itr_setting;
 	u32 tx_itr_setting;
@@ -571,6 +570,7 @@ struct igb_adapter {
 	struct work_struct dma_err_task;
 	bool fc_autoneg;
 	u8  tx_timeout_factor;
+	bool is_detached;
 
 #ifdef DEBUG
 	bool tx_hang_detected;


### PR DESCRIPTION
This particular patch is linked with a customer found issue. One of automotive-related clients using igb_avb driver experienced a situation resulting in NULL-pointer dereference, which caused a kernel panic. The code analysis and debug showed that this was due to using E1000_READ_REG macro after a PCIe detach has been detected. There was most probably a race condition where one process was able to detect a detach and as a consequence null the hw_addr in e1000_read_reg function, whereas a parallel one was still able to call a registry read, on an already zeroed base address. (The direct registry call causing the RIP was noticed in igb_configure_tx_ring, but the situation might have occurred elsewhere, therefore the fix is generic)

Our proposal consists of a couple of basic changes. First of all, we’re not NULL’ing the hw_addr anymore. As a consequence we’re not utilizing the E1000_REMOVED macro (it basically checks whether the base address is not equal to zero). Instead of that we’re adding an additional flag in igb_adapter structure (called is_detached) which is used as an indicator whether the card has already been detached or not. It is necessary to do so, because after a PCIe detach is detected, the driver code still operates and there are sporadic registry reads over there. So in order to prevent the SW reading from an address associated with a card that has been detached and is not present in the system anymore (PCIE config space is 0xFF’ed), were using a goto mechanism and the is_detached flag in order to jump directly to “PCiE detached” print. As a consequence after the unexpected card detach (due to either improper reset line behavior or simply PCIe bus problem) the driver detects it properly and does not continue to read anything from the memory (even through the e1000_read-Reg method is still called). Additionally the “value” variable used as a return var is initialized by default with 0xFFFFFFFF, and assigned some proper values only is case of expected and safe registry read with the use of hw_add base address.

The changes have been deeply tested in both normal and invalid scenario. We checked for regression in case of standard traffic and proper registry reads. Apart from that we simulated and tested the “PCIe detach” case several times, by physically unplugging the card as well as performing SW based pci_bus down operation. The tests did not show any downside and the fix itself prevents the driver from causing an “unable to handle kernel paging” error.
