### PR TITLE
Fix compilation with kernel 5.4+

### DIFF
--- a/kmod/Makefile
+++ b/kmod/Makefile
@@ -264,9 +264,9 @@ $(DRIVER_NAME)-objs := $(CFILES:.c=.o)
 else
 default:
 ifeq ($(KOBJ),$(KSRC))
-	$(MAKE) -C $(KSRC) SUBDIRS=$(shell pwd) modules
+	$(MAKE) -C $(KSRC) M=$(shell pwd) modules
 else
-	$(MAKE) -C $(KSRC) O=$(KOBJ) SUBDIRS=$(shell pwd) modules
+	$(MAKE) -C $(KSRC) O=$(KOBJ) M=$(shell pwd) modules
 endif
 endif
 

--- a/kmod/igb_main.c
+++ b/kmod/igb_main.c
@@ -5569,7 +5569,11 @@ static void igb_tx_map(struct igb_ring *tx_ring,
 	struct sk_buff *skb = first->skb;
 	struct igb_tx_buffer *tx_buffer;
 	union e1000_adv_tx_desc *tx_desc;
+	#ifdef HAVE_SKB_FRAG_STRUCT
 	struct skb_frag_struct *frag;
+	#else
+	skb_frag_t *frag;
+	#endif
 	dma_addr_t dma;
 	unsigned int data_len, size;
 	u32 tx_flags = first->tx_flags;
@@ -8606,7 +8610,11 @@ static void igb_pull_tail(struct igb_ring *rx_ring,
 			  union e1000_adv_rx_desc *rx_desc,
 			  struct sk_buff *skb)
 {
+	#ifdef HAVE_SKB_FRAG_STRUCT
 	struct skb_frag_struct *frag = &skb_shinfo(skb)->frags[0];
+	#else
+	skb_frag_t *frag = &skb_shinfo(skb)->frags[0];
+	#endif
 	unsigned char *va;
 	unsigned int pull_len;
 
@@ -8624,7 +8632,11 @@ static void igb_pull_tail(struct igb_ring *rx_ring,
 
 		/* update pointers to remove timestamp header */
 		skb_frag_size_sub(frag, IGB_TS_HDR_LEN);
+		#ifdef HAVE_SKB_FRAG_STRUCT
 		frag->page_offset += IGB_TS_HDR_LEN;
+		#else
+		frag->bv_offset += IGB_TS_HDR_LEN;
+		#endif
 		skb->data_len -= IGB_TS_HDR_LEN;
 		skb->len -= IGB_TS_HDR_LEN;
 
@@ -8644,7 +8656,11 @@ static void igb_pull_tail(struct igb_ring *rx_ring,
 
 	/* update all of the pointers */
 	skb_frag_size_sub(frag, pull_len);
+	#ifdef HAVE_SKB_FRAG_STRUCT
 	frag->page_offset += pull_len;
+	#else
+	frag->bv_offset += pull_len;
+	#endif
 	skb->data_len -= pull_len;
 	skb->tail += pull_len;
 }

--- a/kmod/kcompat.h
+++ b/kmod/kcompat.h
@@ -269,8 +269,10 @@ struct msix_entry {
 #define node_online(node) ((node) == 0)
 #endif
 
+#if ( LINUX_VERSION_CODE < KERNEL_VERSION(5,4,0) )
 #ifndef num_online_cpus
 #define num_online_cpus() smp_num_cpus
+#endif
 #endif
 
 #ifndef cpu_online
@@ -2576,7 +2578,9 @@ extern void _kc_pci_disable_link_state(struct pci_dev *dev, int state);
 #define pci_disable_link_state(p, s) _kc_pci_disable_link_state(p, s)
 #else /* < 2.6.26 */
 #define NETDEV_CAN_SET_GSO_MAX_SIZE
+#if ( LINUX_VERSION_CODE < KERNEL_VERSION(5,4,0) )
 #include <linux/pci-aspm.h>
+#endif /* < 5.4.0 */
 #define HAVE_NETDEV_VLAN_FEATURES
 #ifndef PCI_EXP_LNKCAP_ASPMS
 #define PCI_EXP_LNKCAP_ASPMS 0x00000c00 /* ASPM Support */
@@ -4724,5 +4728,9 @@ static inline bool page_is_pfmemalloc(struct page __maybe_unused *page)
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(5,2,0))
 #define HAVE_NDO_SELECT_FALLBACK
 #endif /* 5.2.0 */
+
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,4,0))
+#define HAVE_SKB_FRAG_STRUCT
+#endif /* 5.4.0 */
 
 #endif /* _KCOMPAT_H_ */


### PR DESCRIPTION
 - Change make argument from SUBDIRS to M
 - Change struct to skb_frag_t -> bio_vec
 - Exclude num_online_cpus and pci-aspm if kernel > 5.4

Signed-off-by: Markus Eckert <meckert@blackned.de>