### PR TITLE
fix compilation for kernels 5.5+

### DIFF
--- a/kmod/igb_ethtool.c
+++ b/kmod/igb_ethtool.c
@@ -58,7 +58,7 @@ struct igb_stats {
 
 #define IGB_STAT(_name, _stat) { \
 	.stat_string = _name, \
-	.sizeof_stat = FIELD_SIZEOF(struct igb_adapter, _stat), \
+	.sizeof_stat = sizeof_field(struct igb_adapter, _stat), \
 	.stat_offset = offsetof(struct igb_adapter, _stat) \
 }
 
@@ -114,7 +114,7 @@ static const struct igb_stats igb_gstrings_stats[] = {
 
 #define IGB_NETDEV_STAT(_net_stat) { \
 	.stat_string = #_net_stat, \
-	.sizeof_stat = FIELD_SIZEOF(struct net_device_stats, _net_stat), \
+	.sizeof_stat = sizeof_field(struct net_device_stats, _net_stat), \
 	.stat_offset = offsetof(struct net_device_stats, _net_stat) \
 }
 

--- a/kmod/igb_main.c
+++ b/kmod/igb_main.c
@@ -171,7 +171,11 @@ static int igb_poll(struct napi_struct *, int);
 static bool igb_clean_tx_irq(struct igb_q_vector *);
 static bool igb_clean_rx_irq(struct igb_q_vector *, int);
 static int igb_ioctl(struct net_device *, struct ifreq *, int cmd);
+#if ( LINUX_VERSION_CODE < KERNEL_VERSION(5,6,0) )
 static void igb_tx_timeout(struct net_device *);
+#else
+static void igb_tx_timeout(struct net_device *, unsigned int txqueue);
+#endif
 static void igb_reset_task(struct work_struct *);
 #ifdef HAVE_VLAN_RX_REGISTER
 static void igb_vlan_mode(struct net_device *, struct vlan_group *);
@@ -5902,7 +5906,11 @@ static netdev_tx_t igb_xmit_frame(struct sk_buff *skb,
  * igb_tx_timeout - Respond to a Tx Hang
  * @netdev: network interface device structure
  **/
+ #if ( LINUX_VERSION_CODE < KERNEL_VERSION(5,6,0) )
 static void igb_tx_timeout(struct net_device *netdev)
+#else
+static void igb_tx_timeout(struct net_device *netdev, unsigned int txqueue)
+#endif
 {
 	struct igb_adapter *adapter = netdev_priv(netdev);
 	struct e1000_hw *hw = &adapter->hw;
@@ -9691,7 +9699,7 @@ static pci_ers_result_t igb_io_error_detected(struct pci_dev *pdev,
 			pci_write_config_dword(vfdev, 0xA8, 0x00008000);
 		}
 
-		pci_cleanup_aer_uncorrect_error_status(pdev);
+		pci_aer_clear_nonfatal_status(pdev);
 	}
 
 	/*
@@ -9751,7 +9759,7 @@ static pci_ers_result_t igb_io_slot_reset(struct pci_dev *pdev)
 		result = PCI_ERS_RESULT_RECOVERED;
 	}
 
-	pci_cleanup_aer_uncorrect_error_status(pdev);
+	pci_aer_clear_nonfatal_status(pdev);
 
 	return result;
 }

--- a/kmod/kcompat.h
+++ b/kmod/kcompat.h
@@ -1974,10 +1974,6 @@ static inline unsigned _kc_compare_ether_addr(const u8 *addr1, const u8 *addr2)
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
 #endif
 
-#ifndef FIELD_SIZEOF
-#define FIELD_SIZEOF(t, f) (sizeof(((t*)0)->f))
-#endif
-
 #ifndef skb_is_gso
 #ifdef NETIF_F_TSO
 #define skb_is_gso _kc_skb_is_gso
@@ -4708,6 +4704,12 @@ static inline bool page_is_pfmemalloc(struct page __maybe_unused *page)
 #define HAVE_GENEVE_RX_OFFLOAD
 #endif /* 4.5.0 */
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(4,16,0))
+#ifndef sizeof_field
+#define sizeof_field(t, f) (sizeof(((t*)0)->f))
+#endif
+#endif /* 4.16.0 */
+
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4,19,0))
 #else
 #define HAVE_NDO_SELECT_QUEUE_SB_DEV
@@ -4732,5 +4734,9 @@ static inline bool page_is_pfmemalloc(struct page __maybe_unused *page)
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(5,4,0))
 #define HAVE_SKB_FRAG_STRUCT
 #endif /* 5.4.0 */
+
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5,7,0))
+#define pci_aer_clear_nonfatal_status(x) pci_cleanup_aer_uncorrect_error_status(x)
+#endif /* 5.7.0 */
 
 #endif /* _KCOMPAT_H_ */


### PR DESCRIPTION
add the pci-subsystem error-flag rename to kcompat;
remove FIELD_SIZEOF, it's been removed completely in favor of sizeof_field (functionally the same);
add the queue param to igb_tx_timeout, which is also in mainline