### PR TITLE
libigb: Add RXDCTL.ENABLE bit polling when configuring Rx queues

### DIFF
--- a/lib/igb_internal.h
+++ b/lib/igb_internal.h
@@ -95,6 +95,9 @@
 #define PICOSECS_PER_TICK	20833
 #define TSYNC_PORT		319 /* UDP port for the protocol */
 
+/* RXDCTL.ENABLE bit poll retries */
+#define IGB_RXDCTL_MAX_POLL		(5)
+
 struct igb_tx_buffer {
 	int next_eop; /* Index of the desc to watch */
 	struct igb_packet *packet; /* app-relevant handle */


### PR DESCRIPTION
According to I210 datasheet RXDCTL.ENABLE bit shall be polled to confirm
that all operations on the queue are done. This fixes the issue when
sometimes RXDCTL0.ENABLE bit was not set after igb_init() was called.

Reference - I210 datasheet:

  4.5.9 Receive Initialization
  ...
    8. Poll the RXDCTL register until the ENABLE bit is set. The tail should not be bumped before this bit was read as one.
  ...

  4.5.9.2 Dynamic Enabling and Disabling of Receive Queues
  ...
  Disabling a Queue:
  ...
    4. The I210-CS/CL clears RXDCTL.ENABLE only after all pending memory accesses to the descriptor ring or to the buffers are done. The software device driver should poll this bit before releasing the memory allocated to this queue.
  ...