### PR TITLE
Fixes for kernels up to 6.1

### DIFF
--- a/kmod/igb_ethtool.c
+++ b/kmod/igb_ethtool.c
@@ -2021,7 +2021,13 @@ static int igb_phys_id(struct net_device *netdev, u32 data)
 #endif /* HAVE_ETHTOOL_SET_PHYS_ID */
 
 static int igb_set_coalesce(struct net_device *netdev,
+#ifdef HAVE_ETHTOOL_COALESCE_EXT
+			    struct ethtool_coalesce *ec,
+			    struct kernel_ethtool_coalesce *kernel_coal,
+			    struct netlink_ext_ack *extack)
+#else
 			    struct ethtool_coalesce *ec)
+#endif
 {
 	struct igb_adapter *adapter = netdev_priv(netdev);
 	int i;
@@ -2103,7 +2109,13 @@ static int igb_set_coalesce(struct net_device *netdev,
 }
 
 static int igb_get_coalesce(struct net_device *netdev,
+#ifdef HAVE_ETHTOOL_COALESCE_EXT
+			    struct ethtool_coalesce *ec,
+			    struct kernel_ethtool_coalesce *kernel_coal,
+			    struct netlink_ext_ack *extack)
+#else
 			    struct ethtool_coalesce *ec)
+#endif
 {
 	struct igb_adapter *adapter = netdev_priv(netdev);
 

--- a/kmod/igb_ethtool.c
+++ b/kmod/igb_ethtool.c
@@ -897,7 +897,13 @@ static void igb_get_drvinfo(struct net_device *netdev,
 }
 
 static void igb_get_ringparam(struct net_device *netdev,
+#ifdef HAVE_ETHTOOL_RINGPARAM_EXT
+			      struct ethtool_ringparam *ring,
+			      struct kernel_ethtool_ringparam *kernel_ring,
+			      struct netlink_ext_ack *extack)
+#else
 			      struct ethtool_ringparam *ring)
+#endif
 {
 	struct igb_adapter *adapter = netdev_priv(netdev);
 
@@ -912,7 +918,13 @@ static void igb_get_ringparam(struct net_device *netdev,
 }
 
 static int igb_set_ringparam(struct net_device *netdev,
+#ifdef HAVE_ETHTOOL_RINGPARAM_EXT
+			     struct ethtool_ringparam *ring,
+			     struct kernel_ethtool_ringparam *kernel_ring,
+			     struct netlink_ext_ack *extack)
+#else
 			     struct ethtool_ringparam *ring)
+#endif
 {
 	struct igb_adapter *adapter = netdev_priv(netdev);
 	struct igb_ring *temp_ring;

--- a/kmod/igb_ethtool.c
+++ b/kmod/igb_ethtool.c
@@ -3156,6 +3156,9 @@ static int igb_set_channels(struct net_device *dev,
 
 #endif /* ETHTOOL_SCHANNELS */
 static const struct ethtool_ops igb_ethtool_ops = {
+#ifdef HAVE_ETHTOOL_COALESCE_PARAMS
+	.supported_coalesce_params = ETHTOOL_COALESCE_USECS,
+#endif
 	.get_drvinfo            = igb_get_drvinfo,
 	.get_regs_len           = igb_get_regs_len,
 	.get_regs               = igb_get_regs,

--- a/kmod/igb_main.c
+++ b/kmod/igb_main.c
@@ -7411,7 +7411,7 @@ static bool igb_clean_tx_irq(struct igb_q_vector *q_vector)
 			break;
 
 		/* prevent any other reads prior to eop_desc */
-		read_barrier_depends();
+		smp_rmb();
 
 		/* if DD is not set pending work has not been completed */
 		if (!(eop_desc->wb.status & cpu_to_le32(E1000_TXD_STAT_DD)))

--- a/kmod/igb_main.c
+++ b/kmod/igb_main.c
@@ -2409,7 +2409,11 @@ static const struct net_device_ops igb_netdev_ops = {
 	.ndo_set_rx_mode	= igb_set_rx_mode,
 	.ndo_set_mac_address	= igb_set_mac,
 	.ndo_change_mtu		= igb_change_mtu,
+#ifdef HAVE_NDO_ETH_IOCTL
+	.ndo_eth_ioctl		= igb_ioctl,
+#else
 	.ndo_do_ioctl		= igb_ioctl,
+#endif
 	.ndo_tx_timeout		= igb_tx_timeout,
 	.ndo_validate_addr	= eth_validate_addr,
 	.ndo_vlan_rx_add_vid	= igb_vlan_rx_add_vid,

--- a/kmod/igb_main.c
+++ b/kmod/igb_main.c
@@ -6519,7 +6519,7 @@ static int igb_vf_configure(struct igb_adapter *adapter, int vf)
 {
 	unsigned char mac_addr[ETH_ALEN];
 
-	random_ether_addr(mac_addr);
+	eth_random_addr(mac_addr);
 	igb_set_vf_mac(adapter, vf, mac_addr);
 
 #ifdef IFLA_VF_MAX
@@ -7037,7 +7037,7 @@ static void igb_vf_reset_event(struct igb_adapter *adapter, u32 vf)
 
 	/* generate a new mac address as we were hotplug removed/added */
 	if (!(adapter->vf_data[vf].flags & IGB_VF_FLAG_PF_SET_MAC))
-		random_ether_addr(vf_mac);
+		eth_random_addr(vf_mac);
 
 	/* process remaining reset events */
 	igb_vf_reset(adapter, vf);

--- a/kmod/igb_main.c
+++ b/kmod/igb_main.c
@@ -1216,7 +1216,11 @@ static int igb_alloc_q_vector(struct igb_adapter *adapter,
 #endif
 	/* initialize NAPI */
 	netif_napi_add(adapter->netdev, &q_vector->napi,
+#ifdef HAVE_NETIF_NAPI_ADD_WEIGHT_REMOVED
+		       igb_poll);
+#else
 		       igb_poll, 64);
+#endif
 
 	/* tie q_vector and adapter together */
 	adapter->q_vector[v_idx] = q_vector;

--- a/kmod/kcompat.h
+++ b/kmod/kcompat.h
@@ -4759,4 +4759,8 @@ static inline bool page_is_pfmemalloc(struct page __maybe_unused *page)
 #define HAVE_ETHTOOL_RINGPARAM_EXT
 #endif /* 5.17.0 */
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,1,0))
+#define HAVE_NETIF_NAPI_ADD_WEIGHT_REMOVED
+#endif /* 6.1.0 */
+
 #endif /* _KCOMPAT_H_ */

--- a/kmod/kcompat.h
+++ b/kmod/kcompat.h
@@ -752,6 +752,13 @@ struct _kc_ethtool_pauseparam {
 #define UTS_UBUNTU_RELEASE_ABI 0
 #define UBUNTU_VERSION_CODE 0
 #else
+
+#if UTS_UBUNTU_RELEASE_ABI > 255
+/* UTS_UBUNTU_RELEASE_ABI is too large... */
+#undef UTS_UBUNTU_RELEASE_ABI
+#define UTS_UBUNTU_RELEASE_ABI 255
+#endif /* UTS_UBUNTU_RELEASE_ABI > 255 */
+
 /* Ubuntu does not provide actual release version macro, so we use the kernel
  * version plus the ABI to generate a unique version code specific to Ubuntu.
  * In addition, we mask the lower 8 bits of LINUX_VERSION_CODE in order to
@@ -760,10 +767,6 @@ struct _kc_ethtool_pauseparam {
  * ordering checks.
  */
 #define UBUNTU_VERSION_CODE (((LINUX_VERSION_CODE & ~0xFF) << 8) + (UTS_UBUNTU_RELEASE_ABI))
-
-#if UTS_UBUNTU_RELEASE_ABI > 255
-#error UTS_UBUNTU_RELEASE_ABI is too large...
-#endif /* UTS_UBUNTU_RELEASE_ABI > 255 */
 
 #if ( LINUX_VERSION_CODE <= KERNEL_VERSION(3,0,0) )
 /* Our version code scheme does not make sense for non 3.x or newer kernels,

--- a/kmod/kcompat.h
+++ b/kmod/kcompat.h
@@ -4739,6 +4739,10 @@ static inline bool page_is_pfmemalloc(struct page __maybe_unused *page)
 #define pci_aer_clear_nonfatal_status(x) pci_cleanup_aer_uncorrect_error_status(x)
 #endif /* 5.7.0 */
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,7,0))
+#define HAVE_ETHTOOL_COALESCE_PARAMS
+#endif /* 5.7.0 */
+
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,0))
 #define HAVE_ETHTOOL_COALESCE_EXT
 #endif /* 5.15.0 */

--- a/kmod/kcompat.h
+++ b/kmod/kcompat.h
@@ -4745,6 +4745,7 @@ static inline bool page_is_pfmemalloc(struct page __maybe_unused *page)
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,0))
 #define HAVE_ETHTOOL_COALESCE_EXT
+#define HAVE_NDO_ETH_IOCTL
 #endif /* 5.15.0 */
 
 #endif /* _KCOMPAT_H_ */

--- a/kmod/kcompat.h
+++ b/kmod/kcompat.h
@@ -4739,4 +4739,8 @@ static inline bool page_is_pfmemalloc(struct page __maybe_unused *page)
 #define pci_aer_clear_nonfatal_status(x) pci_cleanup_aer_uncorrect_error_status(x)
 #endif /* 5.7.0 */
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,0))
+#define HAVE_ETHTOOL_COALESCE_EXT
+#endif /* 5.15.0 */
+
 #endif /* _KCOMPAT_H_ */

--- a/kmod/kcompat.h
+++ b/kmod/kcompat.h
@@ -4748,4 +4748,8 @@ static inline bool page_is_pfmemalloc(struct page __maybe_unused *page)
 #define HAVE_NDO_ETH_IOCTL
 #endif /* 5.15.0 */
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(3,6,0))
+#define eth_random_addr(addr) random_ether_addr(addr)
+#endif /* 3.6.0 */
+
 #endif /* _KCOMPAT_H_ */

--- a/kmod/kcompat.h
+++ b/kmod/kcompat.h
@@ -4752,4 +4752,8 @@ static inline bool page_is_pfmemalloc(struct page __maybe_unused *page)
 #define eth_random_addr(addr) random_ether_addr(addr)
 #endif /* 3.6.0 */
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,17,0))
+#define HAVE_ETHTOOL_RINGPARAM_EXT
+#endif /* 5.17.0 */
+
 #endif /* _KCOMPAT_H_ */


### PR DESCRIPTION
Ubuntu 22.04 ships with kernel v5.15. I updated driver to compile and work with that kernel. I also verified that it still works on Ubuntu 18.04 with kernel v5.4.

I went further and updated driver to compile with latest available kernel from ubuntu 22.04 repos v6.1.

Some changes overlap with:
https://github.com/Avnu/igb_avb/pull/30
but mine uses compatibility macros.