### PR TITLE
Build for Kernel 6.3

### DIFF
--- a/kmod/e1000_82575.c
+++ b/kmod/e1000_82575.c
@@ -1670,7 +1670,7 @@ static s32 e1000_setup_serdes_link_82575(struct e1000_hw *hw)
 	case E1000_CTRL_EXT_LINK_MODE_1000BASE_KX:
 		/* disable PCS autoneg and support parallel detect only */
 		pcs_autoneg = false;
-		/* fall through to default case */
+		fallthrough;
 	default:
 		if (hw->mac.type == e1000_82575 ||
 		    hw->mac.type == e1000_82576) {
@@ -1796,7 +1796,7 @@ static s32 e1000_get_media_type_82575(struct e1000_hw *hw)
 			dev_spec->sgmii_active = true;
 			break;
 		}
-		/* fall through for I2C based SGMII */
+		fallthrough;
 	case E1000_CTRL_EXT_LINK_MODE_PCIE_SERDES:
 		/* read media type from SFP EEPROM */
 #ifdef I2C_ENABLED

--- a/kmod/e1000_mbx.c
+++ b/kmod/e1000_mbx.c
@@ -516,6 +516,7 @@ s32 e1000_init_mbx_params_pf(struct e1000_hw *hw)
 		mbx->stats.reqs = 0;
 		mbx->stats.acks = 0;
 		mbx->stats.rsts = 0;
+		fallthrough;
 	default:
 		return E1000_SUCCESS;
 	}

--- a/kmod/e1000_nvm.c
+++ b/kmod/e1000_nvm.c
@@ -904,7 +904,7 @@ void e1000_get_fw_version(struct e1000_hw *hw, struct e1000_fw_version *fw_vers)
 			e1000_read_invm_version(hw, fw_vers);
 			return;
 		}
-		/* fall through */
+		fallthrough;
 	case e1000_i350:
 		hw->nvm.ops.read(hw, NVM_ETRACK_HIWORD, 1, &etrack_test);
 		/* find combo image version */

--- a/kmod/e1000_phy.c
+++ b/kmod/e1000_phy.c
@@ -1216,6 +1216,7 @@ s32 e1000_copper_link_setup_m88_gen2(struct e1000_hw *hw)
 			phy_data |= M88E1000_PSCR_AUTO_X_1000T;
 			break;
 		}
+		fallthrough;
 	case 0:
 	default:
 		phy_data |= M88E1000_PSCR_AUTO_X_MODE;

--- a/kmod/igb_ethtool.c
+++ b/kmod/igb_ethtool.c
@@ -2692,11 +2692,11 @@ static int igb_get_rss_hash_opts(struct igb_adapter *adapter,
 	switch (cmd->flow_type) {
 	case TCP_V4_FLOW:
 		cmd->data |= RXH_L4_B_0_1 | RXH_L4_B_2_3;
-		/* Fall through */
+		fallthrough;
 	case UDP_V4_FLOW:
 		if (adapter->flags & IGB_FLAG_RSS_FIELD_IPV4_UDP)
 			cmd->data |= RXH_L4_B_0_1 | RXH_L4_B_2_3;
-		/* Fall through */
+		fallthrough;
 	case SCTP_V4_FLOW:
 	case AH_ESP_V4_FLOW:
 	case AH_V4_FLOW:
@@ -2706,11 +2706,11 @@ static int igb_get_rss_hash_opts(struct igb_adapter *adapter,
 		break;
 	case TCP_V6_FLOW:
 		cmd->data |= RXH_L4_B_0_1 | RXH_L4_B_2_3;
-		/* Fall through */
+		fallthrough;
 	case UDP_V6_FLOW:
 		if (adapter->flags & IGB_FLAG_RSS_FIELD_IPV6_UDP)
 			cmd->data |= RXH_L4_B_0_1 | RXH_L4_B_2_3;
-		/* Fall through */
+		fallthrough;
 	case SCTP_V6_FLOW:
 	case AH_ESP_V6_FLOW:
 	case AH_V6_FLOW:
@@ -3037,13 +3037,13 @@ static unsigned int igb_max_rss_queues(struct igb_adapter *adapter)
 			max_rss_queues = 1;
 			break;
 		}
-		/* fall through */
+		fallthrough;
 	case e1000_82576:
 		if (adapter->vfs_allocated_count) {
 			max_rss_queues = 2;
 			break;
 		}
-		/* fall through */
+		fallthrough;
 	case e1000_82580:
 	default:
 		max_rss_queues = IGB_MAX_RX_QUEUES;
@@ -3130,6 +3130,7 @@ static int igb_set_channels(struct net_device *dev,
 		/* The PF has 3 interrupts and 1 queue pair w/ SR-IOV */
 		if (adapter->vfs_allocated_count)
 			break;
+		fallthrough;
 	case e1000_82576:
 		/*
 		 * The PF has access to 6 interrupt vectors if the number of
@@ -3139,7 +3140,7 @@ static int igb_set_channels(struct net_device *dev,
 		if ((adapter->vfs_allocated_count > 0) &&
 		    (adapter->vfs_allocated_count < 7))
 			break;
-		/* fall through */
+		fallthrough;
 	case e1000_82580:
 	case e1000_i210:
 	default:

--- a/kmod/igb_main.c
+++ b/kmod/igb_main.c
@@ -2927,7 +2927,11 @@ static int igb_probe(struct pci_dev *pdev,
 	/* copy the MAC address out of the NVM */
 	if (e1000_read_mac_addr(hw))
 		dev_err(pci_dev_to_dev(pdev), "NVM Read Error\n");
+#ifdef HAS_ETH_HW_ADDR_SET
+	eth_hw_addr_set(netdev, hw->mac.addr);
+#else
 	memcpy(netdev->dev_addr, hw->mac.addr, netdev->addr_len);
+#endif /* HAS_ETH_HW_ADDR_SET */
 #ifdef ETHTOOL_GPERMADDR
 	memcpy(netdev->perm_addr, hw->mac.addr, netdev->addr_len);
 
@@ -4454,7 +4458,11 @@ static int igb_set_mac(struct net_device *netdev, void *p)
 	if (!is_valid_ether_addr(addr->sa_data))
 		return -EADDRNOTAVAIL;
 
+#ifdef HAS_ETH_HW_ADDR_SET
+	eth_hw_addr_set(netdev, addr->sa_data);
+#else
 	memcpy(netdev->dev_addr, addr->sa_data, netdev->addr_len);
+#endif /* HAS_ETH_HW_ADDR_SET */
 	memcpy(hw->mac.addr, addr->sa_data, netdev->addr_len);
 
 	/* set the correct pool for the new PF MAC address in entry 0 */

--- a/kmod/igb_main.c
+++ b/kmod/igb_main.c
@@ -1143,13 +1143,14 @@ static void igb_set_interrupt_capability(struct igb_adapter *adapter, bool msix)
 		dev_warn(pci_dev_to_dev(pdev),
 			 "Failed to initialize MSI-X interrupts. Falling back to MSI interrupts.\n");
 		igb_reset_interrupt_capability(adapter);
+		fallthrough;
 	case IGB_INT_MODE_MSI:
 		if (!pci_enable_msi(pdev))
 			adapter->flags |= IGB_FLAG_HAS_MSI;
 		else
 			dev_warn(pci_dev_to_dev(pdev),
 				"Failed to initialize MSI interrupts.  Falling back to legacy interrupts.\n");
-		/* Fall through */
+		fallthrough;
 	case IGB_INT_MODE_LEGACY:
 		/* disable advanced features and set number of queues to 1 */
 		igb_reset_sriov_capability(adapter);
@@ -2577,7 +2578,7 @@ static void igb_set_fw_version(struct igb_adapter *adapter)
 			    fw.invm_major, fw.invm_minor, fw.invm_img_type);
 			break;
 		}
-		/* fall through */
+		fallthrough;
 	default:
 		/* if option rom is valid, display its version too*/
 		if (fw.or_valid) {
@@ -4825,6 +4826,7 @@ bool igb_has_link(struct igb_adapter *adapter)
 	case e1000_media_type_copper:
 		if (!hw->mac.get_link_status)
 			return true;
+		fallthrough;
 	case e1000_media_type_internal_serdes:
 		e1000_check_for_link(hw);
 		link_active = !hw->mac.get_link_status;
@@ -6489,7 +6491,7 @@ static int __igb_notify_dca(struct device *dev, void *data)
 			igb_setup_dca(adapter);
 			break;
 		}
-		/* Fall Through since DCA is disabled. */
+		fallthrough;
 	case DCA_PROVIDER_REMOVE:
 		if (adapter->flags & IGB_FLAG_DCA_ENABLED) {
 			/* without this a class_device is left
@@ -10026,13 +10028,13 @@ static void igb_vmm_control(struct igb_adapter *adapter)
 		reg |= (E1000_DTXCTL_VLAN_ADDED |
 			E1000_DTXCTL_SPOOF_INT);
 		E1000_WRITE_REG(hw, E1000_DTXCTL, reg);
-		/* Fall through */
+		fallthrough;
 	case e1000_82580:
 		/* enable replication vlan tag stripping */
 		reg = E1000_READ_REG(hw, E1000_RPLOLR);
 		reg |= E1000_RPLOLR_STRVLAN;
 		E1000_WRITE_REG(hw, E1000_RPLOLR, reg);
-		/* Fall through */
+		fallthrough;
 	case e1000_i350:
 	case e1000_i354:
 		/* none of the above registers are supported by i350 */

--- a/kmod/igb_param.c
+++ b/kmod/igb_param.c
@@ -643,6 +643,7 @@ void igb_check_options(struct igb_adapter *adapter)
 						    adapter);
 				if (adapter->rss_queues)
 					break;
+				fallthrough;
 			case 0:
 				adapter->rss_queues = min_t(u32, opt.arg.r.max,
 							    num_online_cpus());

--- a/kmod/igb_ptp.c
+++ b/kmod/igb_ptp.c
@@ -1013,7 +1013,7 @@ static int igb_ptp_set_timestamp_mode(struct igb_adapter *adapter,
 			config->rx_filter = HWTSTAMP_FILTER_ALL;
 			break;
 		}
-		/* fall through */
+		fallthrough;
 	default:
 		config->rx_filter = HWTSTAMP_FILTER_NONE;
 		return -ERANGE;

--- a/kmod/kcompat.h
+++ b/kmod/kcompat.h
@@ -4763,4 +4763,14 @@ static inline bool page_is_pfmemalloc(struct page __maybe_unused *page)
 #define HAVE_NETIF_NAPI_ADD_WEIGHT_REMOVED
 #endif /* 6.1.0 */
 
+#ifndef __has_attribute
+#define __GCC4_has_attribute___fallthrough__ 0
+#endif
+
+#if __has_attribute(__fallthrough__)
+#define fallthrough __attribute__((__fallthrough__))
+#else
+#define fallthrough do {} while (0)  /* fallthrough */
+#endif
+
 #endif /* _KCOMPAT_H_ */

--- a/kmod/kcompat.h
+++ b/kmod/kcompat.h
@@ -4773,4 +4773,8 @@ static inline bool page_is_pfmemalloc(struct page __maybe_unused *page)
 #define fallthrough do {} while (0)  /* fallthrough */
 #endif
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5,15,0))
+#define HAS_ETH_HW_ADDR_SET
+#endif /* 5.15.0 */
+
 #endif /* _KCOMPAT_H_ */

--- a/kmod/kcompat.h
+++ b/kmod/kcompat.h
@@ -4777,4 +4777,8 @@ static inline bool page_is_pfmemalloc(struct page __maybe_unused *page)
 #define HAS_ETH_HW_ADDR_SET
 #endif /* 5.15.0 */
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6,2,0))
+#define HAVE_PTP_ADJFREQ
+#endif /* 6.2.0 */
+
 #endif /* _KCOMPAT_H_ */


### PR DESCRIPTION
In our Yocto-based GyroidOS, we use a vanilla kernel and lately switched to the rolling-stable branch which is currently on v6.3. This PR contains patches using compatibility macros to compile on v6.3.
I tested this on 6.2 and 6.3 releases. Previously, we also used v5.4 kernel from debian and a vanillla 5.4.
Those still work, too

