### PR TITLE
Build on kernel 6.6 and 6.7

### DIFF
--- a/kmod/kcompat.h
+++ b/kmod/kcompat.h
@@ -4781,4 +4781,9 @@ static inline bool page_is_pfmemalloc(struct page __maybe_unused *page)
 #define HAVE_PTP_ADJFREQ
 #endif /* 6.2.0 */
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,6,0))
+#define pci_enable_pcie_error_reporting(pdev)
+#define pci_disable_pcie_error_reporting(pdev)
+#endif /* 6.6.0 */
+
 #endif /* _KCOMPAT_H_ */


### PR DESCRIPTION
Rolling stable moved to 6.6 some weeks ago.
I integrated the necessary changes compared to the mainline driver,
see the commit messages for detail.

These changes, should be backward compatible with older kernels.

We have loaded the driver successfully on the latest 6.6.x releases.
I also tested to compile against the current 6.7-rc6 but did not yet use
this at runtime.