### PR TITLE
Build on 6.11

### DIFF
--- a/kmod/e1000_osdep.h
+++ b/kmod/e1000_osdep.h
@@ -69,8 +69,8 @@
 #define DEBUGOUT(S) pr_debug(S)
 #define DEBUGOUT1(S, A...) pr_debug(S, ## A)
 #else
-#define DEBUGOUT(S)
-#define DEBUGOUT1(S, A...)
+#define DEBUGOUT(S) do { } while (0)
+#define DEBUGOUT1(S, A...) do { } while (0)
 #endif
 
 #ifdef DEBUG_FUNC

--- a/kmod/igb_ethtool.c
+++ b/kmod/igb_ethtool.c
@@ -2266,7 +2266,7 @@ static void igb_get_strings(struct net_device *netdev, u32 stringset, u8 *data)
 
 #ifdef HAVE_ETHTOOL_GET_TS_INFO
 static int igb_get_ts_info(struct net_device *dev,
-			   struct ethtool_ts_info *info)
+			   struct kernel_ethtool_ts_info *info)
 {
 	struct igb_adapter *adapter = netdev_priv(dev);
 

--- a/kmod/igb_main.c
+++ b/kmod/igb_main.c
@@ -78,11 +78,7 @@
 #define DRV_HW_PERF
 #define VERSION_SUFFIX "_AVB"
 
-#define MAJ 5
-#define MIN 3
-#define BUILD 2
-#define DRV_VERSION __stringify(MAJ) "." __stringify(MIN) "."\
-	__stringify(BUILD) VERSION_SUFFIX DRV_DEBUG DRV_HW_PERF
+#define DRV_VERSION "5.3.2" VERSION_SUFFIX DRV_DEBUG DRV_HW_PERF
 
 char igb_driver_name[] = "igb_avb";
 char igb_driver_version[] = DRV_VERSION;

--- a/kmod/igb_main.c
+++ b/kmod/igb_main.c
@@ -2645,7 +2645,7 @@ static void igb_init_mas(struct igb_adapter *adapter)
 	}
 }
 
-void igb_rar_set(struct igb_adapter *adapter, u32 index)
+static void igb_rar_set(struct igb_adapter *adapter, u32 index)
 {
 	u32 rar_low, rar_high;
 	struct e1000_hw *hw = &adapter->hw;
@@ -4552,7 +4552,7 @@ int igb_write_mc_addr_list(struct net_device *netdev)
 	return count;
 }
 
-void igb_sync_mac_table(struct igb_adapter *adapter)
+static void igb_sync_mac_table(struct igb_adapter *adapter)
 {
 	struct e1000_hw *hw = &adapter->hw;
 	int i;
@@ -5364,7 +5364,7 @@ set_itr_now:
 	}
 }
 
-void igb_tx_ctxtdesc(struct igb_ring *tx_ring, u32 vlan_macip_lens,
+static void igb_tx_ctxtdesc(struct igb_ring *tx_ring, u32 vlan_macip_lens,
 		     u32 type_tucmd, u32 mss_l4len_idx)
 {
 	struct e1000_adv_tx_context_desc *context_desc;
@@ -6564,7 +6564,7 @@ static void igb_ping_all_vfs(struct igb_adapter *adapter)
  *  current value is read, the new bit is OR'd in and the new value is
  *  written back into the register.
  **/
-void igb_mta_set(struct igb_adapter *adapter, u32 hash_value)
+static void igb_mta_set(struct igb_adapter *adapter, u32 hash_value)
 {
 	struct e1000_hw *hw = &adapter->hw;
 	u32 hash_bit, hash_reg, mta;
@@ -7330,7 +7330,7 @@ static irqreturn_t igb_intr(int irq, void *data)
 	return IRQ_HANDLED;
 }
 
-void igb_ring_irq_enable(struct igb_q_vector *q_vector)
+static void igb_ring_irq_enable(struct igb_q_vector *q_vector)
 {
 	struct igb_adapter *adapter = q_vector->adapter;
 	struct e1000_hw *hw = &adapter->hw;

--- a/kmod/igb_main.c
+++ b/kmod/igb_main.c
@@ -1987,7 +1987,7 @@ void igb_reinit_locked(struct igb_adapter *adapter)
  *
  * @adapter: adapter struct
  **/
-void igb_enable_mas(struct igb_adapter *adapter)
+static void igb_enable_mas(struct igb_adapter *adapter)
 {
 	struct e1000_hw *hw = &adapter->hw;
 	u32 connsw;
@@ -2108,6 +2108,10 @@ void igb_reset(struct igb_adapter *adapter)
 		igb_check_options(adapter);
 		e1000_get_bus_info(hw);
 		adapter->flags &= ~IGB_FLAG_MEDIA_RESET;
+	}
+	if ((mac->type == e1000_82575) &&
+	    (adapter->flags & IGB_FLAG_MAS_ENABLE)) {
+		igb_enable_mas(adapter);
 	}
 	if (e1000_init_hw(hw))
 		dev_err(pci_dev_to_dev(pdev), "Hardware Error\n");

--- a/kmod/igb_main.c
+++ b/kmod/igb_main.c
@@ -155,7 +155,6 @@ static u16 igb_select_queue(struct net_device *dev, struct sk_buff *skb);
 static netdev_tx_t igb_xmit_frame(struct sk_buff *skb, struct net_device *);
 static struct net_device_stats *igb_get_stats(struct net_device *);
 static int igb_change_mtu(struct net_device *, int);
-/* void igb_full_sync_mac_table(struct igb_adapter *adapter); */
 static int igb_set_mac(struct net_device *, void *);
 static void igb_set_uta(struct igb_adapter *adapter);
 static irqreturn_t igb_intr(int irq, void *);
@@ -4547,15 +4546,6 @@ int igb_write_mc_addr_list(struct net_device *netdev)
 	kfree(mta_list);
 
 	return count;
-}
-
-void igb_full_sync_mac_table(struct igb_adapter *adapter)
-{
-	struct e1000_hw *hw = &adapter->hw;
-	int i;
-
-	for (i = 0; i < hw->mac.rar_entry_count; i++)
-		igb_rar_set(adapter, i);
 }
 
 void igb_sync_mac_table(struct igb_adapter *adapter)

--- a/kmod/igb_main.c
+++ b/kmod/igb_main.c
@@ -312,7 +312,9 @@ static void igb_init_dmac(struct igb_adapter *adapter, u32 pba);
 /* user-mode IO API registrations */
 static struct file_operations igb_fops = {
 		.owner   = THIS_MODULE,
+#ifdef HAVE_FS_NO_LLSEEK
 		.llseek  = no_llseek,
+#endif
 		.read	= igb_read,
 		.write   = igb_write,
 		.poll	= igb_pollfd,

--- a/kmod/kcompat.h
+++ b/kmod/kcompat.h
@@ -4799,4 +4799,10 @@ static inline void skb_frag_off_add(skb_frag_t *frag, int delta)
 #define HAVE_ETHTOOL_LINKMODE_HELPERS
 #endif /* 6.9.0 */
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6,11,0))
+#ifndef kernel_ethtool_ts_info
+#define kernel_ethtool_ts_info ethtool_ts_info
+#endif
+#endif /* 6.11.0 */
+
 #endif /* _KCOMPAT_H_ */

--- a/kmod/kcompat.h
+++ b/kmod/kcompat.h
@@ -4805,4 +4805,8 @@ static inline void skb_frag_off_add(skb_frag_t *frag, int delta)
 #endif
 #endif /* 6.11.0 */
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6,12,0))
+#define HAVE_FS_NO_LLSEEK
+#endif /* 6.12.0 */
+
 #endif /* _KCOMPAT_H_ */


### PR DESCRIPTION
Rolling stable advanced to 6.11.3 a few days ago.

I integrated the necessary change to compile on 6.11 in the commit:
kmod: net: Add struct kernel_ethtool_ts_info (https://github.com/Avnu/igb_avb/commit/3e5c322d45881b0975be272d1e75b0524d4a027f)

The rest of the commits are fixing compiler warnings, see commit messages for details.