### PR TITLE
kmod: igb_main: Use slow_virt_to_phys() instead of virt_to_phys()

### DIFF
--- a/kmod/igb_main.c
+++ b/kmod/igb_main.c
@@ -10677,7 +10677,7 @@ static long igb_mapbuf(struct file *file, void __user *arg, int ring)
 		igb_priv->uring_tx_init |= (1 << req.queue);
 
 		if(ring == IGB_IOCTL_MAP_TX_RING)	
-			req.pa = virt_to_phys(adapter->tx_ring[req.queue]->desc);
+			req.pa = slow_virt_to_phys(adapter->tx_ring[req.queue]->desc);
 
 		req.physaddr = adapter->tx_ring[req.queue]->dma;
 		req.mmap_size = adapter->tx_ring[req.queue]->size;
@@ -10711,7 +10711,7 @@ static long igb_mapbuf(struct file *file, void __user *arg, int ring)
 		igb_priv->uring_rx_init |= (1 << req.queue);
 		
 		if(ring == IGB_IOCTL_MAP_RX_RING)	
-			req.pa = virt_to_phys(adapter->rx_ring[req.queue]->desc);
+			req.pa = slow_virt_to_phys(adapter->rx_ring[req.queue]->desc);
 
 		req.physaddr = adapter->rx_ring[req.queue]->dma;
 		req.mmap_size = adapter->rx_ring[req.queue]->size;

--- a/kmod/kcompat.h
+++ b/kmod/kcompat.h
@@ -4188,6 +4188,9 @@ extern int __kc_netif_set_xps_queue(struct net_device *, struct cpumask *, u16);
 extern u16 __kc_netdev_pick_tx(struct net_device *dev, struct sk_buff *skb);
 #define __netdev_pick_tx __kc_netdev_pick_tx
 #endif /* HAVE_NETDEV_SELECT_QUEUE */
+
+#define slow_virt_to_phys(virt_addr) virt_to_phys(virt_addr)
+
 #else
 #define HAVE_BRIDGE_FILTER
 #define HAVE_FDB_DEL_NLATTR


### PR DESCRIPTION
In kernel >=v6.8.0 virt_to_phys() returns address which is not usable from userspace. It was working fine in kernels up to v6.7.x.

I failed to find which exactly commit (or maybe kernel config option) causes that change of behaviour. What I understand, neither virt_to_phys() nor slow_virt_to_phys() should be used in drivers for dma transfers, we are triggering dma transfers from userspace which is even more evil.