### PR TITLE
Build for Linux v6.17 and v6.18

### DIFF
--- a/kmod/igb_main.c
+++ b/kmod/igb_main.c
@@ -2215,6 +2215,9 @@ static int igb_ndo_fdb_add(struct ndmsg *ndm, struct nlattr *tb[],
 			   u16 vid,
 #endif
 			   u16 flags
+#ifdef HAVE_NDO_FDB_ADD_NOTIFIED
+			   , bool *notified
+#endif
 #ifdef HAVE_NDO_FDB_ADD_EXT_ACK
 			   , struct netlink_ext_ack *extack
 #endif

--- a/kmod/igb_main.c
+++ b/kmod/igb_main.c
@@ -1915,7 +1915,7 @@ void igb_down(struct igb_adapter *adapter)
        	and watchdog - performing required actions
        	before altering the adapter state and registers
      	*/
-    	del_timer_sync(&adapter->watchdog_timer);
+    	timer_delete_sync(&adapter->watchdog_timer);
     	cancel_work_sync(&adapter->watchdog_task);    
 
 	/* signal that we're down so the interrupt handler does not
@@ -1947,8 +1947,8 @@ void igb_down(struct igb_adapter *adapter)
 	adapter->flags &= ~IGB_FLAG_NEED_LINK_UPDATE;
 	
 	if (adapter->flags & IGB_FLAG_DETECT_BAD_DMA)
-		del_timer_sync(&adapter->dma_err_timer);
-	del_timer_sync(&adapter->phy_info_timer);
+		timer_delete_sync(&adapter->dma_err_timer);
+	timer_delete_sync(&adapter->phy_info_timer);
 
 	/* record the stats before reset*/
 	igb_update_stats(adapter);
@@ -3263,10 +3263,10 @@ static void igb_remove(struct pci_dev *pdev)
 	 * disable watchdog from being rescheduled.
 	 */
 	set_bit(__IGB_DOWN, &adapter->state);
-	del_timer_sync(&adapter->watchdog_timer);
+	timer_delete_sync(&adapter->watchdog_timer);
 	if (adapter->flags & IGB_FLAG_DETECT_BAD_DMA)
-		del_timer_sync(&adapter->dma_err_timer);
-	del_timer_sync(&adapter->phy_info_timer);
+		timer_delete_sync(&adapter->dma_err_timer);
+	timer_delete_sync(&adapter->phy_info_timer);
 
 	cancel_work_sync(&adapter->reset_task);
 	if (adapter->flags & IGB_FLAG_DETECT_BAD_DMA)

--- a/kmod/kcompat.h
+++ b/kmod/kcompat.h
@@ -4809,4 +4809,9 @@ static inline void skb_frag_off_add(skb_frag_t *frag, int delta)
 #define HAVE_FS_NO_LLSEEK
 #endif /* 6.12.0 */
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,13,0))
+#define HAVE_NDO_FDB_ADD_NOTIFIED
+#endif /* 6.13.0 */
+
+
 #endif /* _KCOMPAT_H_ */

--- a/kmod/kcompat.h
+++ b/kmod/kcompat.h
@@ -4813,5 +4813,9 @@ static inline void skb_frag_off_add(skb_frag_t *frag, int delta)
 #define HAVE_NDO_FDB_ADD_NOTIFIED
 #endif /* 6.13.0 */
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(6,15,0))
+#define timer_delete_sync(timer) del_timer_sync(timer)
+#endif /* 6.15.0 */
+
 
 #endif /* _KCOMPAT_H_ */


### PR DESCRIPTION
This PR contains the latest changes to compile for Kernel v6.17

The latest stable kernel I tested to load the module was v6.17.5

I also compiled it against v6.18-rc2 source. However, I did not tested to actually run it on hardware.
